### PR TITLE
feat: support repetitive query param via an array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, 'feature/*', 'feat/*', 'bugfix/*', 'hotfix/*', 'fix/*', 'refactor/*', 'release/*', 'test/*', 'docs/*', 'chore/*'] # All branches
+    branches: [
+        main,
+        develop,
+        'feature/*',
+        'feat/*',
+        'bugfix/*',
+        'hotfix/*',
+        'fix/*',
+        'refactor/*',
+        'release/*',
+        'test/*',
+        'docs/*',
+        'chore/*',
+      ] # All branches
   pull_request:
     branches: [main, develop]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,7 +200,7 @@ export interface EditSubscriptionParams {
 }
 
 export interface EditTagParams {
-  i: string | string[] // Stream ID
+  i: string | string[] // Item ID(s)
   a?: string // Add tag
   r?: string // Remove tag
   ac?: string // Action

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,7 +200,7 @@ export interface EditSubscriptionParams {
 }
 
 export interface EditTagParams {
-  s: string // Stream ID
+  i: string | string[] // Stream ID
   a?: string // Add tag
   r?: string // Remove tag
   ac?: string // Action

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,14 @@ export function buildUrl(baseUrl: string, path: string, params?: Record<string, 
   if (params) {
     for (const [key, value] of Object.entries(params)) {
       if (value !== undefined && value !== null) {
-        url.searchParams.append(key, String(value))
+        if (Array.isArray(value)) {
+          // Handle array values by appending each item
+          for (const item of value) {
+            url.searchParams.append(key, String(item))
+          }
+        } else {
+          url.searchParams.append(key, String(value))
+        }
       }
     }
   }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -66,6 +66,21 @@ describe('Utils', () => {
       expect(url).toBe('https://example.com/api/test?param=value')
     })
 
+    it('should handle empty parameters', () => {
+      const url = buildUrl('https://example.com', '/api/test', {})
+      expect(url).toBe('https://example.com/api/test')
+    })
+
+    it('should handle undefined parameters', () => {
+      const url = buildUrl('https://example.com', '/api/test', undefined)
+      expect(url).toBe('https://example.com/api/test')
+    })
+
+    it('should handle array parameters', () => {
+      const url = buildUrl('https://example.com', '/api/test', { id: ['1', '2', '3'] })
+      expect(url).toBe('https://example.com/api/test?id=1&id=2&id=3')
+    })
+
     it('should build URL without parameters', () => {
       const url = buildUrl('https://example.com', '/api/test')
       expect(url).toBe('https://example.com/api/test')


### PR DESCRIPTION
## Description

The http request function now supports setting repetitive query parameters when given an array. This is to support the use case for [Edit Tag](https://www.inoreader.com/developers/edit-tag) endpoint, when a tag can be applied to multiple items, to save bandwidth and request count.

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Maintenance
- [ ] Other (please describe):

---

## Checklist

- [x] Code has been linted with `bun run lint`
- [x] Code has been formatted with `bun run format`
- [x] Documentation has been updated (if applicable)
- [x] All tests pass in CI/CD for Node.js, Bun, and Deno
- [x] I have merged the latest changes from the main branch